### PR TITLE
Add ng2-pdfjs-viewer (Angular PDF viewer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Yet another curated List of Angular 2+ Components &amp; Libraries.
 ### PDF
 
 - [VadimDez/ng2-pdf-viewer](https://github.com/VadimDez/ng2-pdf-viewer) - 📄 PDF Viewer Component for Angular 5+
+- [intbot/ng2-pdfjs-viewer](https://github.com/intbot/ng2-pdfjs-viewer) - 📄 Comprehensive Angular PDF viewer built on PDF.js: annotations, forms, signatures, search, and read-aloud. Angular 10-22.
 
 ### Tree
 - [500tech/angular-tree-component](https://github.com/500tech/angular-tree-component) - A simple yet powerful tree component for Angular (>=2) 


### PR DESCRIPTION
Adds **ng2-pdfjs-viewer**, an Angular PDF viewer component built on Mozilla PDF.js (on npm since 2018, 8.3M+ downloads, supports Angular 10 through 22). It fills the Angular entry in the viewers section: annotations, AcroForms, signatures, search, page organization, and read-aloud from one component.

- npm: https://www.npmjs.com/package/ng2-pdfjs-viewer
- repo: https://github.com/intbot/ng2-pdfjs-viewer
